### PR TITLE
Remove unused workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,11 +12,6 @@ workflows:
           inputs:
             - workflow: e2e
 
-  test:
-    after_run:
-      - check
-      - e2e
-
   sample:
     envs:
       - TEST_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-cocoapods-no-shared-schemes.git


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Remove old validation workflows that were used in the old CI setup. These are not used anymore and only `check` and `e2e` are needed.

Part of https://bitrise.atlassian.net/browse/STEP-1144
