### PR TITLE
Add default value for the project path input

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -26,7 +26,7 @@ toolkit:
   go:
     package_name: github.com/bitrise-steplib/steps-recreate-user-schemes
 inputs:
-- project_path:
+- project_path: $BITRISE_PROJECT_PATH
   opts:
     title: Project or Workspace path
     summary: A `.xcodeproj/.xcworkspace` path.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

The step did not have a default value for the project path input. The other steps are using the `$BITRISE_PROJECT_PATH` and this step should use the same. 
